### PR TITLE
add multiple threads with a parameter of threads

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -25,5 +25,6 @@ mapping:
       date-format: 'yyyy-MM-dd'
       date-start: '2010-01-01'
       date-end: '2018-06-01'
+      threads: 8
   sink:
     split-index-by-field: 'type'

--- a/ingester/__main__.py
+++ b/ingester/__main__.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
         es_sink_conn = ElasticConnector(es_sink_conf)
         es_sink = ElasticIndexer(es_sink_conn, sink_params['es']['index-name'])
 
+
         # initialize the indexer
         mapping = config.params['mapping']
         indexer = BatchAnnotationsIndexer(nlp_service=nlp_service,
@@ -79,7 +80,9 @@ if __name__ == "__main__":
                                           split_index_by_field=mapping['sink']['split-index-by-field'],
                                           sink_indexer=es_sink,
                                           source_batch_date_field=mapping['source']['batch']['date-field'],
-                                          batch_date_format=mapping['source']['batch']['date-format'])
+                                          batch_date_format=mapping['source']['batch']['date-format'],
+                                          threads=mapping['source']['batch']['threads'])
+
     except Exception as e:
         log = logging.getLogger('main')
         log.error("Cannot initialize the application: " + str(e))

--- a/ingester/annotations_indexer.py
+++ b/ingester/annotations_indexer.py
@@ -23,7 +23,7 @@ class AnnotationsIndexer:
     MIN_TEXT_LEN = 10
 
     def __init__(self, nlp_service, source_indexer, source_text_field, source_docid_field,
-                 source_fields_to_persist, sink_indexer, split_index_by_field="", use_bulk_indexing=True, threads=1):
+                 source_fields_to_persist, sink_indexer, split_index_by_field="", threads=1, use_bulk_indexing=True):
         """
         :param nlp_service: the NLP service to use :class:~`NlpService`
         :param source_indexer: the source ElasticSearch indexer :class:`~ElasticIndexer`
@@ -138,6 +138,7 @@ class AnnotationsIndexer:
         """
         Performs full document processing cycle for the specified document id
         """
+        self.log.info('Processing document with id: ' + src_doc_id)
         doc = self.source_indexer.get_doc(src_doc_id)
 
         # check whether there is document content to process
@@ -192,9 +193,8 @@ class AnnotationsIndexer:
         doc_ids = self._get_doc_ids()
 
         self.log.info('Found documents: %d' % len(doc_ids))
-        for doc_id in doc_ids:
-            self.log.info('Processing document with id: ' + doc_id)
-            self._process_document(doc_id)
+        with ThreadPoolExecutor(max_workers=self.threads) as executor:
+            executor.map(self._process_document, doc_ids)
 
 
 ################################
@@ -209,7 +209,7 @@ class BatchAnnotationsIndexer(AnnotationsIndexer):
 
     def __init__(self, nlp_service, source_indexer, source_text_field, source_docid_field,
                  source_fields_to_persist, sink_indexer,
-                 source_batch_date_field, batch_date_format="yyyy-MM-dd", split_index_by_field=""):
+                 source_batch_date_field, batch_date_format="yyyy-MM-dd", split_index_by_field="", threads=1):
         """
         :param nlp_service: the NLP service to use :class:~`NlpService`
         :param source_indexer: the source ElasticSearch indexer :class:`~ElasticIndexer`
@@ -221,7 +221,7 @@ class BatchAnnotationsIndexer(AnnotationsIndexer):
         :param split_index_by_field: optional, the name of the field by which the sink index should be split
         """
         super().__init__(nlp_service, source_indexer, source_text_field, source_docid_field,
-                         source_fields_to_persist, sink_indexer, split_index_by_field)
+                         source_fields_to_persist, sink_indexer, split_index_by_field, threads)
 
         self.source_batch_date_field = source_batch_date_field
         self.batch_date_format = batch_date_format
@@ -245,8 +245,5 @@ class BatchAnnotationsIndexer(AnnotationsIndexer):
         doc_ids = self._get_doc_ids_range(batch_date_start, batch_date_end)
 
         self.log.info('Found documents: %d' % len(doc_ids))
-        # for doc_id in doc_ids:
-        #     self.log.info('Processing document with id: ' + doc_id)
-        #     self._process_document(doc_id)
         with ThreadPoolExecutor(max_workers=self.threads) as executor:
             executor.map(self._process_document, doc_ids)


### PR DESCRIPTION
Added a "threads" parameter in config file to indicate the number of processing threads in annotations' ingester;
Added a parameter of "threads" in BatchAnnotationsIndexer of annotations_indexer.py.
Modified the function "index_range" of in annotations_indexer.py to use multiple threads. 
